### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ For instance you can download all the summaries available with:
 s <- seq(from = as.Date("2009/01/01", "%Y/%m/%d"), to = Sys.Date(), by = 1)
 done <- vapply(s, function(x){
     sumario <- sumario_xml(format(as.Date(x, "%Y/%m/%d"), "%Y%m%d"))
-    xml2::download_xml(httr::query_xml(sumario))
+    xml2::download_xml(BOE::query_xml(sumario))
 })
 ```


### PR DESCRIPTION
When I tried the _readme_ example didn't work. It's just the function namespace.
Should be fine now, wanted to PRequest for my github points, sorry if too minimal

Old: 

``` r
library(BOE)
s <- seq(from = as.Date("2009/01/01", "%Y/%m/%d"), to = Sys.Date(), by = 1)
done <- vapply(s, function(x){
    sumario <- sumario_xml(format(as.Date(x, "%Y/%m/%d"), "%Y%m%d"))
    xml2::download_xml(BOE::query_xml(sumario))
})
#> Error in vapply(s, function(x) {: el argumento "FUN.VALUE" está ausente, sin valor por omisión
sessionInfo()
#> R version 3.6.0 (2019-04-26)
#> Platform: x86_64-w64-mingw32/x64 (64-bit)
#> Running under: Windows 10 x64 (build 17134)
#> 
#> Matrix products: default
#> 
#> locale:
#> [1] LC_COLLATE=Spanish_Spain.1252  LC_CTYPE=Spanish_Spain.1252   
#> [3] LC_MONETARY=Spanish_Spain.1252 LC_NUMERIC=C                  
#> [5] LC_TIME=Spanish_Spain.1252    
#> 
#> attached base packages:
#> [1] stats     graphics  grDevices utils     datasets  methods   base     
#> 
#> other attached packages:
#> [1] BOE_0.1.0
#> 
#> loaded via a namespace (and not attached):
#>  [1] Rcpp_1.0.1      digest_0.6.19   R6_2.4.0        magrittr_1.5   
#>  [5] evaluate_0.14   highr_0.8       httr_1.4.1      stringi_1.4.3  
#>  [9] xml2_1.2.2      rmarkdown_1.13  tools_3.6.0     stringr_1.4.0  
#> [13] xfun_0.8        yaml_2.2.0      compiler_3.6.0  htmltools_0.3.6
#> [17] knitr_1.23
```

<sup>Created on 2019-11-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>


