### PR TITLE
update readme 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,18 @@ anuncio("2012", "32498")
 For instance you can download all the summaries available with:
 
 ``` r
-s <- seq(from = as.Date("2009/01/01", "%Y/%m/%d"), to = Sys.Date(), by = 1)
-done <- vapply(s, function(x){
+library(BOE)
+path = fs::dir_create("BOE_xml")
+# available from 2009/01/01
+s <- seq(from = as.Date("2019/10/01", "%Y/%m/%d"),
+         to = Sys.Date(),
+         by = 1)
+done <- purrr::map(s, function(x){
     sumario <- sumario_xml(format(as.Date(x, "%Y/%m/%d"), "%Y%m%d"))
-    xml2::download_xml(BOE::query_xml(sumario))
+    xml2::download_xml(url = BOE::query_xml(sumario),
+                       file = fs::path(path,
+                                       glue::glue("{x}.xml")))
 })
 ```
+
+


### PR DESCRIPTION
Okay so I am stupid and I didn't test if the example code was working as expected. 

I had this error:

``` r
library(BOE)
s <- seq(from = as.Date("2009/01/01", "%Y/%m/%d"), to = Sys.Date(), by = 1)
done <- vapply(s, function(x){
    sumario <- sumario_xml(format(as.Date(x, "%Y/%m/%d"), "%Y%m%d"))
    xml2::download_xml(BOE::query_xml(sumario))
})
#> Error in vapply(s, function(x) {: el argumento "FUN.VALUE" está ausente, sin valor por omisión
```

<sup>Created on 2019-11-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Also inside the `vlapply` call I got an error from `xml2` about the file name. I think this might be windows specific though. 

Here is how I re-wrote it. There might be some style choices. Feel free to remove the `fs` or `glue` calls. It's just more clear for me.

Now it creates a BOE_xml folder and it downloads the range there.